### PR TITLE
Introduced MustacheContext and fixed partials resolving

### DIFF
--- a/lib/angel_mustache.dart
+++ b/lib/angel_mustache.dart
@@ -4,23 +4,25 @@ import 'dart:io';
 import 'package:angel_framework/angel_framework.dart';
 import 'package:mustache4dart/mustache4dart.dart' show render;
 import 'package:angel_mustache/src/cache.dart';
+import 'package:angel_mustache/src/mustache_context.dart';
+import 'package:path/path.dart' as path;
 
 mustache(Directory viewsDirectory,
     {String fileExtension: '.mustache', String partialsPath: './partials'}) {
+  Directory partialsDirectory =
+      new Directory(path.join(path.fromUri(viewsDirectory.uri), partialsPath));
 
-  Directory partialsDirectory = new Directory.fromUri(
-  viewsDirectory.uri.resolve(partialsPath));
-  
-  MustacheCacheController cache = new MustacheCacheController(
-    viewsDirectory, partialsDirectory, fileExtension);
+  MustacheContext context =
+      new MustacheContext(viewsDirectory, partialsDirectory, fileExtension);
+
+  MustacheCacheController cache = new MustacheCacheController(context);
 
   return (Angel app) async {
     app.viewGenerator = (String name, [Map data]) async {
       var partialsProvider;
       partialsProvider = (String name) {
-          String template = cache.get_partial(name, app);
-          return render(template, data ?? {},
-              partial: partialsProvider);
+        String template = cache.get_partial(name, app);
+        return render(template, data ?? {}, partial: partialsProvider);
       };
 
       String viewTemplate = await cache.get_view(name, app);

--- a/lib/src/mustache_context.dart
+++ b/lib/src/mustache_context.dart
@@ -1,0 +1,22 @@
+import 'dart:io';
+import 'package:path/path.dart' as path;
+
+class MustacheContext {
+  Directory viewDirectory;
+
+  Directory partialDirectory;
+
+  String extension;
+
+  MustacheContext([this.viewDirectory, this.partialDirectory, this.extension]);
+
+  File resolveView(String viewName) {
+    return new File.fromUri(
+        viewDirectory.uri.resolve('${viewName}${extension}'));
+  }
+
+  File resolvePartial(String partialName) {
+    return new File.fromUri(
+        partialDirectory.uri.resolve('${partialName}${extension}'));
+  }
+}


### PR DESCRIPTION
1. Partials are now resolved with the 'path' package (tested with and without leading '.')
2. MustacheContext is an object that holds all folder contextual information for views and partials, and cleanly isolates all file resolving in one location

Let me know if there are any issues.